### PR TITLE
[Feat] 작업 중지 반응성 개선: 현재 태스크 즉시 취소 로직 적용

### DIFF
--- a/app/core/upscale_video.py
+++ b/app/core/upscale_video.py
@@ -16,12 +16,14 @@ class VideoUpscaler:
         self,
         image_upscaler: ImageUpscaler,
         ffmpeg_handler: FFmpegHandler,
-        temp_dir: str = "temp"
+        temp_dir: str = "temp",
+        should_stop: Optional[Callable[[], bool]] = None
     ):
         self.image_upscaler = image_upscaler
         self.ffmpeg = ffmpeg_handler
         self.temp_dir = Path(temp_dir)
         self.temp_dir.mkdir(parents=True, exist_ok=True)
+        self.should_stop = should_stop
     
     def upscale_video(
         self,
@@ -109,6 +111,11 @@ class VideoUpscaler:
                 return False
             
             for idx, frame_file in enumerate(frame_files):
+                # 중간 정지 추가
+                if self.should_stop and self.should_stop():
+                    logger.info("Video upscale cancelled by user")
+                    return False
+                
                 output_frame = frames_out_dir / frame_file.name
                 
                 # 진행률 업데이트

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -79,6 +79,9 @@ class Worker(QThread):
         self.all_tasks_completed.emit()
     
     def _process_task(self, task: UpscaleTask):
+        """현재 작업 id 저장"""
+        self.current_task_id = task.task_id
+
         """작업 처리."""
         logger.info(f"Processing task: {task.task_id}")
         
@@ -133,6 +136,9 @@ class Worker(QThread):
                 error=str(e)
             )
             self.task_failed.emit(task.task_id, str(e))
+
+        finally:
+            self.current_task_id = None
     
     def _load_model(self, model_name: str) -> bool:
         """AI 모델 로드."""
@@ -240,4 +246,12 @@ class Worker(QThread):
     def stop(self):
         """워커 중지."""
         self._stop_requested = True
+
+        # 현재 작업도 취소 상태로 변경 (progress_callback 에서 즉시 감지)
+        if getattr(self, "current_task_id", None):
+            self.task_queue.update_task(
+                self.current_task_id,
+                status=TaskStatus.CANCELLED,
+                message="사용자에 의해 중지됨"
+            )
         logger.info("Worker stop requested")

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -179,7 +179,7 @@ class Worker(QThread):
         
         def progress_callback(progress):
             # 취소 확인
-            if task.status == TaskStatus.CANCELLED:
+            if self._stop_requested or task.status == TaskStatus.CANCELLED:
                 raise InterruptedError("Task cancelled")
             
             self.task_queue.update_task(

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -79,10 +79,9 @@ class Worker(QThread):
         self.all_tasks_completed.emit()
     
     def _process_task(self, task: UpscaleTask):
-        """현재 작업 id 저장"""
+        """현재 작업 id 저장 후 작업 처리"""
         self.current_task_id = task.task_id
 
-        """작업 처리."""
         logger.info(f"Processing task: {task.task_id}")
         
         # 작업 시작

--- a/app/core/worker.py
+++ b/app/core/worker.py
@@ -177,6 +177,10 @@ class Worker(QThread):
     def _process_image_task(self, task: UpscaleTask) -> bool:
         """이미지 작업 처리."""
         
+        if not self.image_upscaler:
+            logger.error("Image upscaler not initialized")
+            return False
+        
         def progress_callback(progress):
             # 취소 확인
             if self._stop_requested or task.status == TaskStatus.CANCELLED:
@@ -202,6 +206,10 @@ class Worker(QThread):
     
     def _process_video_task(self, task: UpscaleTask) -> bool:
         """동영상 작업 처리."""
+        
+        if not self.video_upscaler:
+            logger.error("Video upscaler not initialized")
+            return False
         
         def progress_callback(message, progress):
             # 취소 확인
@@ -248,9 +256,10 @@ class Worker(QThread):
         self._stop_requested = True
 
         # 현재 작업도 취소 상태로 변경 (progress_callback 에서 즉시 감지)
-        if getattr(self, "current_task_id", None):
+        current_task_id = getattr(self, "current_task_id", None)
+        if current_task_id:
             self.task_queue.update_task(
-                self.current_task_id,
+                current_task_id,
                 status=TaskStatus.CANCELLED,
                 message="사용자에 의해 중지됨"
             )


### PR DESCRIPTION
## 변경 사항 요약
사용자의 작업 중지 요청에 즉각 반응할 수 있도록 `Worker`의 중단 로직을 고도화. 
이제 중지 버튼 클릭 시 현재 진행 중인 업스케일링 태스크가 즉시 중단됨. 

### 주요 변경 세부 사항

#### 1. 실시간 태스크 추적 (`current_task_id`)
* `_process_task` 진입 시 `self.current_task_id`를 할당하고, 종료(`finally`) 시 `None`으로 초기화하여 워커가 현재 무엇을 하는지 항상 알 수 있게 함

#### 2. `stop()` 메서드 고도화
* 단순 플래그 변경에서 나아가, `task_queue.update_task`를 직접 호출하여 현재 태스크를 즉시 `CANCELLED` 상태로 강제 전환
* 이를 통해 콜백 내부에서 상태 변화를 즉각 감지 가능

#### 3. 중단 체크 로직 강화 (Double Check)
* `image_upscale` 및 `video_upscale`의 콜백 함수에서 `self._stop_requested`를 명시적으로 체크
* 비디오 업스케일 루프 사이사이에 중단 체크를 수행하여 FFmpeg이나 프레임 합성이 즉시 멈추도록 유도

### 수정된 코드 스니펫
```python
def stop(self):
    self._stop_requested = True
    # 현재 실행 중인 태스크를 즉시 취소 상태로 변경
    tid = getattr(self, "current_task_id", None)
    if tid:
        self.task_queue.update_task(tid, status=TaskStatus.CANCELLED, message="중지됨")
```
(Closed #8)